### PR TITLE
Locked Pandas version to 2.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - matplotlib
   - numpy=1.26.4
   - packaging
-  - pandas
+  - pandas=2.3
   - pillow
   - pyinstaller
   - pyinstaller-hooks-contrib


### PR DESCRIPTION
Previously when creating a report, it would fail with a Pandas error. Locked Pandas to 2.3 so it won't go to 3.0. I tested this by creating an executable locally and putting it in a build and it worked.