### PR TITLE
fix: use active forecast member for gate plots

### DIFF
--- a/src/main/python/WAT_DataOrganizer.py
+++ b/src/main/python/WAT_DataOrganizer.py
@@ -1448,7 +1448,11 @@ class DataOrganizer(object):
                 data[gateopkey]['gates'] = {}
                 line_data[gateopkey]['gates'] = {}
                 for gate in gateop['gates']:
+                    if self.Report.memberiteration:
+                        gate['members'] = [self.Report.member]
                     dates, values, _ = self.getTimeSeries(gate, makecopy=makecopy)
+                    if isinstance(values, dict) and self.Report.member in values:
+                        values = values[self.Report.member]
                     if 'flag' in gate.keys():
                         flag = gate['flag']
                     else:


### PR DESCRIPTION
## Summary
- Limit forecast gate data to the active forecast member during member iteration
- Convert the selected member's gate values back to a single time series before binary gate plotting

## Test Plan
- `python3 -m py_compile src/main/python/WAT_DataOrganizer.py`
- `git diff --check`
- Synthetic `DataOrganizer.getGateDataDictionary` smoke test with a forecast member-iteration gate returning member-keyed values
- `bash ./gradlew assemble` (blocked locally: Java Runtime is not installed on this runner)

Closes #4
